### PR TITLE
Migrate x64 apps to x86 apps

### DIFF
--- a/electron-builder-x64.yml
+++ b/electron-builder-x64.yml
@@ -1,0 +1,16 @@
+appId: 'Overlay-Live-Comment-Viewer-x64'
+productName: 'OverlayLiveCommentViewer (64bit)'
+directories:
+  buildResources: public
+  output: dist
+files: [build, package.json, package-lock.json]
+extraResources: [public]
+mac:
+  target: dmg
+win:
+  target: nsis
+  publish:
+    provider: github
+nsis:
+  oneClick: false
+  allowToChangeInstallationDirectory: true

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "build/main.js",
   "scripts": {
     "develop": "run-s clean:output build:dev serve",
-    "production": "run-s clean:output clean:cache build:pro package:winx64",
+    "production": "run-s clean:output clean:cache build:pro package:winx86",
     "jest": "jest",
     "e2e": "echo todo",
     "lint": "eslint src",
@@ -13,7 +13,8 @@
     "clean:cache": "rimraf node_modules/.cache",
     "build:dev": "cross-env NODE_ENV=\"development\" webpack --progress",
     "build:pro": "cross-env NODE_ENV=\"production\" webpack --progress",
-    "package:winx64": "electron-builder --win --x64",
+    "package:winx64": "electron-builder --win --x64 --config ./electron-builder-x64.yml",
+    "package:winx86": "electron-builder --win --ia32",
     "package:macx64": "electron-builder --mac --x64",
     "serve": "electron .",
     "asar": "asar extract dist/win-unpacked/resources/app.asar dist/win-unpacked/resources/app"


### PR DESCRIPTION
<!-- markdownlint-disable single-h1 -->
<!-- すべての項目を埋めなくてよい -->

# 概要
<!-- 変更した概要を記述してください -->
　要件的に32bitに落としても動作に深刻な影響がないこと。2つのアーキテクチャには自動更新が対応できないこと、32/64両用対応ではファイルが大きくなりすぎるため以上の理由から32bitをデフォルトにする。

# Issue
<!-- このPRを作成するに至ったissueを貼り付けて下さい -->
https://github.com/LenTakayama/Overlay-Live-Comment-Viewer/projects/1#card-52118759
#13 

# 作業内容
<!-- 箇条書きでよいので -->

* productionスクリプトで32bitで出力されるように変更
* GitHub Actionは対応済み
* 64bit専用の設定ファイルを作成（使用用途未定）

# 動作確認項目・レビュー項目

- [x] CIをクリアする
- [x] 基本的な動作確認
