### PR TITLE
Fix save window config

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,21 @@ const store = new Store({
       });
     },
   },
+  defaults: {
+    'comment-window-config': {
+      right: true,
+      bottom: false,
+      width: 400,
+      height: 500,
+    },
+    'insert-css': {
+      css: null,
+    },
+    'load-url': {
+      url: null,
+    },
+  },
+});
 
 log.transports.file.level = 'info';
 log.transports.file.resolvePath = (variables: log.PathVariables) => {
@@ -92,20 +107,8 @@ const getExtraDirectory = () => {
 
 const createCommentWindow = () => {
   // 設定をロード
-  const loadURL = <LoadURL>store.get('load-url', {
-    url: null,
-  });
-  const insertCSS = <InsertCSS>store.get('insert-css', {
-    css: null,
-  });
-  const positionConfig = <PositionConfig>store.get('positionConfig', {
-    right: true,
-    bottom: false,
-  });
-  const windowSize = <WindowSize>store.get('window-size', {
-    width: 400,
-    height: 500,
-  });
+  const loadURL = <LoadURL>store.get('load-url');
+  const insertCSS = <InsertCSS>store.get('insert-css');
   const windowConfig = <WindowConfig>store.get('comment-window-config');
   const position = positionData(
     windowConfig.width,

--- a/types/main.d.ts
+++ b/types/main.d.ts
@@ -1,8 +1,3 @@
-export type PositionConfig = {
-  right: boolean;
-  bottom: boolean;
-};
-
 export type InsertCSS = {
   css: string | null;
 };
@@ -12,6 +7,13 @@ export type LoadURL = {
 };
 
 export type WindowSize = {
+  width: number;
+  height: number;
+};
+
+export type WindowConfig = {
+  right: boolean;
+  bottom: boolean;
   width: number;
   height: number;
 };


### PR DESCRIPTION
<!-- markdownlint-disable single-h1 -->
<!-- すべての項目を埋めなくてよい -->

# 概要
<!-- 変更した概要を記述してください -->
　コメント画面の位置が保存されていないバグに対応

# Issue
<!-- このPRを作成するに至ったissueを貼り付けて下さい -->
#19 

# 作業内容
<!-- 箇条書きでよいので -->

* 画面位置と画面サイズの保存を同一設定項目化
* Storeのデフォルト値設定機能を使いコードをリファクタリング
* 以前の画面サイズ設定を引き継げるようにマイグレーションを設定

# 動作確認項目・レビュー項目

- [x] CIをクリアする
- [x] 画面サイズ・画面位置・URLがアプリ再起動後も引き継がれることを動作確認
