### PR TITLE
わんコメ非公式連携第一弾を実装

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -189,9 +189,6 @@ const createCommentWindow = () => {
     }
   );
   app.once('window-all-closed', () => null);
-  process.env.NODE_ENV === 'development'
-    ? commentView.webContents.openDevTools({ mode: 'detach' })
-    : null;
 };
 
 const createIndexWindow = () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,17 +12,48 @@ import {
 } from 'electron';
 import Store from 'electron-store';
 import { autoUpdater } from 'electron-updater';
-import { resolve, join } from 'path';
+import { resolve, join, sep } from 'path';
 import {
   InsertCSS,
   LoadURL,
   NotificationConfig,
   WindowConfig,
   WindowSize,
+  OneCommeConfig,
 } from '~/types/main';
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
 import log from 'electron-log';
 import '@/src/autoUpdater';
+
+const ONE_COMME_DIR_NAME = 'live-comment-viewer';
+const ONE_COMME_APP_NAME = 'わんコメ - OneComme.exe';
+
+const getOneCommePath = (): string => {
+  // OLCVはローカルインストールとグローバルインストール両方が存在する
+  const pathArray = app.getAppPath().split(sep);
+  // OLCVと同じ階層にあるかまず確認する
+  pathArray.push('..', ONE_COMME_DIR_NAME, ONE_COMME_APP_NAME);
+  const currentPath = join(...pathArray);
+  if (existsSync(currentPath)) {
+    return currentPath;
+  }
+  // なければAppDataから辿る
+  // FIXME: Windowsのみ対応
+  const userDataPathArray = app.getPath('appData').split(sep);
+  userDataPathArray.push(
+    '..',
+    'local',
+    'Programs',
+    ONE_COMME_DIR_NAME,
+    ONE_COMME_APP_NAME
+  );
+  const userDataPath = join(...userDataPathArray);
+  if (existsSync(userDataPath)) {
+    return userDataPath;
+  } else {
+    return '';
+  }
+};
 
 const store = new Store({
   name: 'config',
@@ -56,6 +87,10 @@ const store = new Store({
     notification: {
       noSound: false,
       onBoot: true,
+    },
+    oneCommeConfig: {
+      isBoot: false,
+      path: getOneCommePath(),
     },
   },
 });
@@ -390,6 +425,10 @@ app.on('ready', () => {
     }
     createReadmeWindow();
   }
+  const oneCommeConfig = store.get('oneCommeConfig');
+  if (oneCommeConfig.isBoot && oneCommeConfig.path) {
+    shell.openPath(oneCommeConfig.path);
+  }
 });
 
 ipcMain.handle('ready-index-page', () => {
@@ -489,5 +528,19 @@ ipcMain.handle(
       onBoot: config.onBoot,
     })
 );
+
+ipcMain.handle('one-comme-config', (_event, config: OneCommeConfig) => {
+  store.set('oneCommeConfig', {
+    isBoot: config.isBoot,
+    path: config.path,
+  });
+});
+
+ipcMain.handle('one-comme-boot', () => {
+  const oneCommeConfig = store.get('oneCommeConfig');
+  if (oneCommeConfig.isBoot && oneCommeConfig.path) {
+    shell.openPath(oneCommeConfig.path);
+  }
+});
 
 app.once('window-all-closed', () => null);

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron';
 import { version } from '~/package.json';
-import { NotificationConfig } from '~/types/main';
+import { NotificationConfig, OneCommeConfig } from '~/types/main';
 
 contextBridge.exposeInMainWorld('electronApis', {
   init: async (): Promise<NotificationConfig> =>
@@ -27,4 +27,7 @@ contextBridge.exposeInMainWorld('electronApis', {
   displayComment: async () => await ipcRenderer.invoke('display-comment'),
   sendNotificationConfig: async (config: NotificationConfig) =>
     await ipcRenderer.invoke('set-notification-config', config),
+  sendOneCommeConfig: async (config: OneCommeConfig) =>
+    await ipcRenderer.invoke('one-comme-config', config),
+  sendOneCommeBoot: async () => await ipcRenderer.invoke('one-comme-boot'),
 });

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -11,6 +11,9 @@
       <div class="left">
         <label for="url"><h1>URL</h1></label>
         <input type="text" id="url" name="url" class="url" />
+        <div class="drop-area" id="drop-area">
+          <p>HTMLをここにドロップ</p>
+        </div>
       </div>
       <div class="right">
         <label for="css"><h1>CSS</h1></label>
@@ -59,6 +62,24 @@
         </div>
       </div>
     </div>
+    <details>
+      <summary>
+        <h1>アプリ連携設定</h1>
+      </summary>
+      <div>
+        <label for="one-comme-onboot"
+          >起動時にわんコメをあわせて立ち上げる</label
+        >
+        <input type="checkbox" name="one-comme-onboot" id="one_comme_onboot" />
+        <button class="display" name="one-comme-boot" id="one_comme_boot">
+          わんコメ起動
+        </button>
+      </div>
+      <div>
+        <label for="one-comme-path">わんコメのパス</label>
+        <input type="text" name="one-comme-path" id="one_comme_path" />
+      </div>
+    </details>
     <hr />
     <div>
       <button id="display" class="display">コメント表示</button>

--- a/src/renderer/index.scss
+++ b/src/renderer/index.scss
@@ -58,3 +58,26 @@ textarea,
 .url {
   width: 95%;
 }
+.drop-area {
+  background-color: gray;
+}
+summary {
+  list-style: none;
+  position: relative;
+}
+summary::-webkit-details-marker {
+  display: none;
+}
+summary::after {
+  content: '▽';
+  position: absolute;
+  top: 50%;
+  right: 30px;
+  transform: translateY(-50%);
+  transition: transform 0.5s;
+  font-size: 30px;
+}
+summary:hover,
+details[open] summary {
+  background-color: #bc9e04;
+}

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -16,6 +16,8 @@ class Index {
     this.addSaveClickEvent();
     this.addResetClickEvent();
     this.addDefaultCssClickEvent();
+    this.addDropFileEvent();
+    this.addOneCommeBootButtonClick();
   }
 
   private displayVersion(): void {
@@ -94,17 +96,31 @@ class Index {
         await window.electronApis.sendInsertCSS(cssValue);
         this.css = cssValue;
       }
+      const isOneCommeBoot = (<HTMLInputElement>(
+        document.getElementById('one_comme_onboot')
+      )).checked;
+      const oneCommePath = (<HTMLInputElement>(
+        document.getElementById('one_comme_path')
+      )).value;
+      Promise.all([
+        window.electronApis.sendWindowConfig(
+          Number(widthValue),
+          Number(heightValue),
+          isRight,
+          isBottom
+        ),
+        window.electronApis.sendNotificationConfig({
+          noSound: noSound,
+          onBoot: onBoot,
+        }),
+        window.electronApis.sendOneCommeConfig({
+          isBoot: isOneCommeBoot,
+          path: oneCommePath,
+        }),
+      ])
+        .then()
+        .catch((err) => console.error(err));
       // ロード時にセットするためにローカルストレージに保存
-      await window.electronApis.sendWindowConfig(
-        Number(widthValue),
-        Number(heightValue),
-        isRight,
-        isBottom
-      );
-      await window.electronApis.sendNotificationConfig({
-        noSound: noSound,
-        onBoot: onBoot,
-      });
       localStorage.setItem('width', widthValue);
       localStorage.setItem('height', heightValue);
       localStorage.setItem('right', isRight.toString());
@@ -141,6 +157,60 @@ class Index {
           await window.electronApis.sendDefaultCss();
         }
       });
+  }
+
+  private addDropFileEvent() {
+    const element = document.getElementById('drop-area');
+    if (element) {
+      element.addEventListener(
+        'dragover',
+        function (e) {
+          e.stopPropagation();
+          e.preventDefault();
+          this.style.background = '#e1e7f0';
+        },
+        false
+      );
+      element.addEventListener(
+        'dragleave',
+        function (e) {
+          e.stopPropagation();
+          e.preventDefault();
+          this.style.background = 'darkgrey';
+        },
+        false
+      );
+      const urlElement = document.getElementById('url');
+      if (urlElement) {
+        element.addEventListener(
+          'drop',
+          function (e) {
+            e.stopPropagation();
+            e.preventDefault();
+            this.style.background = 'darkgrey';
+            const files = e.dataTransfer?.files;
+            if (!files) {
+              return;
+            }
+            if (files.length > 1)
+              return alert('アップロードできるファイルは1つだけです。');
+            (<HTMLInputElement>urlElement).value = files.item(0)?.path
+              ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                files.item(0)!.path
+              : '';
+          },
+          false
+        );
+      }
+    }
+  }
+
+  private addOneCommeBootButtonClick() {
+    const button = document.getElementById('one_comme_boot');
+    button?.addEventListener(
+      'click',
+      async () => await window.electronApis.sendOneCommeBoot()
+    );
   }
 }
 

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -119,6 +119,7 @@ class Index {
         }),
       ])
         .then()
+        // eslint-disable-next-line no-console
         .catch((err) => console.error(err));
       // ロード時にセットするためにローカルストレージに保存
       localStorage.setItem('width', widthValue);

--- a/types/main.d.ts
+++ b/types/main.d.ts
@@ -22,3 +22,8 @@ export type NotificationConfig = {
   noSound: boolean;
   onBoot: boolean;
 };
+
+export type OneCommeConfig = {
+  isBoot: boolean;
+  path: string;
+};

--- a/types/window.d.ts
+++ b/types/window.d.ts
@@ -1,5 +1,5 @@
 import { Versions } from './front';
-import { NotificationConfig } from './main';
+import { NotificationConfig, OneCommeConfig } from './main';
 
 declare global {
   interface Window {
@@ -18,6 +18,8 @@ declare global {
       getVersion(): Versions;
       displayComment(): Promise<void>;
       sendNotificationConfig(config: NotificationConfig): Promise<void>;
+      sendOneCommeConfig(config: OneCommeConfig): Promise<void>;
+      sendOneCommeBoot(): Promise<void>;
     };
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable single-h1 -->
<!-- すべての項目を埋めなくてよい -->

# 概要
<!-- 変更した概要を記述してください -->
わんコメをとりあえず連携起動・コメント表示できるようにした。

# Issue
<!-- このPRを作成するに至ったissueを貼り付けて下さい -->
#48 

# 作業内容
<!-- 箇条書きでよいので -->
- HTMLファイルをドラッグして表示できるようにした
- わんコメのパスを設定すればOLCV起動したら一緒に起動できるようした
- 任意のタイミングでわんコメをOLCVから立ち上げるようにした

# 動作確認項目・レビュー項目

- [x] CIをクリアする
- [x] わんコメのパスが設定されているかつ起動時立ち上げて設定になっている場合わんコメが起動する
- [x] わんコメ起動状態でわんコメテンプレートを突っ込むとコメントが表示される
- [x] わんコメのパスが設定されていないかつ起動時立ち上げ設定になっている場合エラーが起きない
