### PR TITLE
Trayにアイコンが残るバグの一部解消

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -33,6 +33,10 @@ export class Application implements ApplicationInterface {
     this.addOnReadyEventHandler();
     this.addOnWebContentsCreatedEventHandler();
     app.on('window-all-closed', () => null);
+    app.once('will-quit', (_e) => {
+      this.tray?.destroy();
+      this.tray = undefined;
+    });
     addIpcMainHandles(this);
   }
   public createSettingWindow(): void {


### PR DESCRIPTION
<!-- markdownlint-disable single-h1 -->
<!-- すべての項目を埋めなくてよい -->

# 概要
<!-- 変更した概要を記述してください -->
アプリを終了させても通知領域にアイコンが残ってしまうためそのバグを修正。
コンソール上からCtrl+Cした場合は解決できてないが、その他の終了ケースでは解決できたと思われる。

# Issue
<!-- このPRを作成するに至ったissueを貼り付けて下さい -->
#53

# 作業内容
<!-- 箇条書きでよいので -->

- will-quitに処理を追加
  - before-quitやquitも試したがコンソール上にはうまくいかなかったことを確認。

# 動作確認項目・レビュー項目

- [ ] CIをクリアする
- [ ] 起動でき、コメント表示など操作ができる
