### PR TITLE
trayアイコンダブルクリックで設定画面の呼び出しができるようにした

### DIFF
--- a/src/tray.ts
+++ b/src/tray.ts
@@ -18,7 +18,7 @@ export function createTray(application: Application): Tray {
         if (application.viewWindow.window) {
           application.viewWindow.window.showInactive();
         } else {
-          application.createViewWindow();
+          application.createSettingWindow();
         }
       },
     },
@@ -70,6 +70,13 @@ export function createTray(application: Application): Tray {
   tray.setContextMenu(menu);
   tray.on('click', () => {
     tray.popUpContextMenu(menu);
+  });
+  tray.on('double-click', () => {
+    if (application.settingWindow.window) {
+      application.settingWindow.window.focus();
+    } else {
+      application.createViewWindow();
+    }
   });
   if (config.onBoot) {
     tray.displayBalloon({


### PR DESCRIPTION
<!-- markdownlint-disable single-h1 -->
<!-- すべての項目を埋めなくてよい -->

# 概要
<!-- 変更した概要を記述してください -->
不便だったのでtrayアイコンダブルクリックで設定画面の呼び出しができるようにした

# Issue
<!-- このPRを作成するに至ったissueを貼り付けて下さい -->
close #68 

# 作業内容
<!-- 箇条書きでよいので -->
- trayにダブルクリックでの動作定義を行った

# 動作確認項目・レビュー項目

- [ ] CIをクリアする
- [ ] ダブルクリックして開いてない場合設定画面が開かれる
- [ ] ダブルクリックしてすでに開いている場合フォーカスされる
